### PR TITLE
Fix WordPress 5.5 compatibility issue

### DIFF
--- a/UserTags.php
+++ b/UserTags.php
@@ -100,7 +100,6 @@ class UserTags {
 		add_filter( "manage_{$taxonomy}_custom_column", array( $this, 'set_user_column_values' ), 10, 3 );
 
 		// Save changes
-		$wp_taxonomies[ $taxonomy ]    = $args;
 		self::$taxonomies[ $taxonomy ] = $args;
 	}
 


### PR DESCRIPTION
This line in ut_registered_taxonomy
```
              // Save changes
              $wp_taxonomies[ $taxonomy ]    = $args;
```
isn't needed, I don't think, and breaks 5.5. Originally taxonomies were stored in $wp_taxonomies as an object with properties but at some point since you originally wrote the plugin they became WP_Taxonomy objects. However the WP_Taxonomy is passed into this hook handler as an array of properties not an object, meaning when we save it back into $wp_taxonomies here it's just a stdClass not a WP_Taxonomy object.

The problem is that 5.5 added a new method on WP_Taxonomy, get_rest_controller(). If the entry in $wp_taxonomies is rewritten as a stdClass not a WP_Taxonomy then when the REST API code tries to call get_rest_controller() on the taxonomy it fails.

It looks like this code once edited $args before it saved it but it doesn't anymore: it just registers two hooks for the taxonomy and saves a copy in the private taxonomy array. So I think it's safe to just delete this line.

Here's a thread about this on [WordPress StackExchange](https://wordpress.stackexchange.com/q/375037/3276).